### PR TITLE
[WIP] Snapshotter - a component for sending snapshots of values

### DIFF
--- a/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
@@ -7,11 +7,14 @@
     public class RingBufferTests
     {
         RingBuffer ringBuffer;
+        IEntryProvider provider;
+
 
         [SetUp]
         public void SetUp()
         {
             ringBuffer = new RingBuffer();
+            provider = ringBuffer;
         }
 
         [Test]
@@ -69,7 +72,7 @@
         {
             // This test is single threaded so no cross-thread aberrations will be visible.
 
-            Assert.AreEqual(0, ringBuffer.RoughlyEstimateItemsToConsume());
+            Assert.AreEqual(0, provider.RoughlyEstimateItemsToConsume());
         }
 
         [Test]
@@ -81,7 +84,7 @@
             WriteValues(values);
             Consume(values);
 
-            Assert.AreEqual(0, ringBuffer.RoughlyEstimateItemsToConsume());
+            Assert.AreEqual(0, provider.RoughlyEstimateItemsToConsume());
         }
 
         [Test]
@@ -92,7 +95,7 @@
             var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
             WriteValues(values);
 
-            Assert.AreEqual(RingBuffer.Size, ringBuffer.RoughlyEstimateItemsToConsume());
+            Assert.AreEqual(RingBuffer.Size, provider.RoughlyEstimateItemsToConsume());
         }
 
         [Test]
@@ -132,7 +135,7 @@
                     // read till it returns
                     do
                     {
-                        read = ringBuffer.Consume(chunk =>
+                        read = provider.Consume(chunk =>
                         {
                             foreach (var value in chunk)
                             {
@@ -154,7 +157,7 @@
 
         void Consume(params long[] values)
         {
-            var read = ringBuffer.Consume(entries =>
+            var read = provider.Consume(entries =>
             {
                 CollectionAssert.AreEqual(values, entries.Select(e => e.Value).ToArray());
             });

--- a/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
@@ -9,7 +9,6 @@
         RingBuffer ringBuffer;
         IEntryProvider provider;
 
-
         [SetUp]
         public void SetUp()
         {

--- a/src/ServiceControl.Monitoring.Data.Tests/SnapshotterTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/SnapshotterTests.cs
@@ -1,0 +1,69 @@
+﻿namespace ServiceControl.Monitoring.Data.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    public class SnapshotterTests
+    {
+        Snapshotter snapshotter;
+        IEntryProvider provider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            snapshotter = new Snapshotter();
+            provider = snapshotter;
+        }
+
+        [Test]
+        public void Empty_should_report_nothing()
+        {
+            AssertConsume();
+        }
+
+        [Test]
+        public void Writing_same_tag_multiples_times_should_report_last_value_once()
+        {
+            const int tag = 1;
+
+            snapshotter.Write(1, tag);
+            snapshotter.Write(2, tag);
+            snapshotter.Write(3, tag);
+
+            AssertConsume(new RingBuffer.Entry
+            {
+                Tag = tag,
+                Value = 3
+            });
+        }
+
+        [Test]
+        public void Writing_mutiple_values()
+        {
+            var entries = new List<RingBuffer.Entry>();
+            for (var i = 1; i < 11; i++)
+            {
+                snapshotter.Write(i, i);
+                entries.Add(new RingBuffer.Entry(0, i, i));
+            }
+
+            AssertConsume(entries);
+        }
+
+        void AssertConsume(params RingBuffer.Entry[] expected)
+        {
+            provider.Consume(chunk => Assert(expected, chunk));
+        }
+
+        void AssertConsume(IEnumerable<RingBuffer.Entry> expected)
+        {
+            provider.Consume(chunk => Assert(expected, chunk));
+        }
+
+        static void Assert(IEnumerable<RingBuffer.Entry> expected, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            NUnit.Framework.Assert.That(chunk, Is.EquivalentTo(expected).Using(new TagValueEntryComparer()));
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.Data.Tests/TagValueEntryComparer.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/TagValueEntryComparer.cs
@@ -1,0 +1,18 @@
+﻿namespace ServiceControl.Monitoring.Data.Tests
+{
+    using System.Collections.Generic;
+
+    class TagValueEntryComparer : IComparer<RingBuffer.Entry>
+    {
+        public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
+        {
+            var result = x.Tag.CompareTo(y.Tag);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            return x.Value.CompareTo(y.Value);
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.Data/IEntryProvider.cs
+++ b/src/ServiceControl.Monitoring.Data/IEntryProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace ServiceControl.Monitoring.Data
+{
+    using System;
+
+    // an interface for items that can be consumed with a writer
+    public interface IEntryProvider
+    {
+        long RoughlyEstimateItemsToConsume();
+        int Consume(Action<ArraySegment<RingBuffer.Entry>> onChunk);
+    }
+}

--- a/src/ServiceControl.Monitoring.Data/RingBuffer.cs
+++ b/src/ServiceControl.Monitoring.Data/RingBuffer.cs
@@ -26,6 +26,11 @@
             public long Ticks;
             public long Value;
             public int Tag;
+
+            public override string ToString()
+            {
+                return $"{nameof(Ticks)}: {Ticks}, {nameof(Value)}: {Value}, {nameof(Tag)}: {Tag}";
+            }
         }
 
         public bool TryWrite(long value, int tag = 0)

--- a/src/ServiceControl.Monitoring.Data/RingBuffer.cs
+++ b/src/ServiceControl.Monitoring.Data/RingBuffer.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Threading;
 
-    public class RingBuffer
+    public class RingBuffer : IEntryProvider
     {
         internal const int Size = 4096;
         const long SizeMask = Size - 1;
@@ -62,13 +62,13 @@
             return true;
         }
 
-        internal long RoughlyEstimateItemsToConsume()
+        long IEntryProvider.RoughlyEstimateItemsToConsume()
         {
             return Volatile.Read(ref nextToWrite) - Volatile.Read(ref nextToConsume);
         }
 
         // Consumes a chunk of entries. This method will call onChunk zero, or one time. No multiple calls will be issued.
-        internal int Consume(Action<ArraySegment<Entry>> onChunk)
+        int IEntryProvider.Consume(Action<ArraySegment<Entry>> onChunk)
         {
             var consume = Interlocked.CompareExchange(ref nextToConsume, 0, 0);
             var max = Volatile.Read(ref nextToWrite);

--- a/src/ServiceControl.Monitoring.Data/Snapshotter.cs
+++ b/src/ServiceControl.Monitoring.Data/Snapshotter.cs
@@ -8,12 +8,12 @@
         readonly ConcurrentDictionary<int, long> values = new ConcurrentDictionary<int, long>();
         RingBuffer.Entry[] entries = new RingBuffer.Entry[32];
 
-        public long RoughlyEstimateItemsToConsume()
+        long IEntryProvider.RoughlyEstimateItemsToConsume()
         {
             return 0;
         }
 
-        public int Consume(Action<ArraySegment<RingBuffer.Entry>> onChunk)
+        int IEntryProvider.Consume(Action<ArraySegment<RingBuffer.Entry>> onChunk)
         {
             var ticks = DateTime.UtcNow.Ticks;
 
@@ -27,7 +27,7 @@
                 }
 
                 entries[i].Tag = kvp.Key;
-                entries[i].Value = kvp.Key;
+                entries[i].Value = kvp.Value;
                 entries[i].Ticks = ticks;
 
                 i += 1;

--- a/src/ServiceControl.Monitoring.Data/Snapshotter.cs
+++ b/src/ServiceControl.Monitoring.Data/Snapshotter.cs
@@ -1,0 +1,46 @@
+﻿namespace ServiceControl.Monitoring.Data
+{
+    using System;
+    using System.Collections.Concurrent;
+
+    public class Snapshotter : IEntryProvider
+    {
+        readonly ConcurrentDictionary<int, long> values = new ConcurrentDictionary<int, long>();
+        RingBuffer.Entry[] entries = new RingBuffer.Entry[32];
+
+        public long RoughlyEstimateItemsToConsume()
+        {
+            return 0;
+        }
+
+        public int Consume(Action<ArraySegment<RingBuffer.Entry>> onChunk)
+        {
+            var ticks = DateTime.UtcNow.Ticks;
+
+            // foreach is used as the iterator over concurrent dictionary is a nonlocking one, enabling reporting when needed.
+            var i = 0;
+            foreach (var kvp in values)
+            {
+                if (i == entries.Length)
+                {
+                    Array.Resize(ref entries, entries.Length * 2);
+                }
+
+                entries[i].Tag = kvp.Key;
+                entries[i].Value = kvp.Key;
+                entries[i].Ticks = ticks;
+
+                i += 1;
+            }
+
+            onChunk(new ArraySegment<RingBuffer.Entry>(entries, 0, i));
+
+            return i;
+        }
+
+        public void Write(long value, int tag)
+        {
+            values[tag] = value;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the Snapshotter. A new component that is capable of accepting writes of tagged values, and report them with RawDataReporter. 

An example usage could be reporting of the queue length sessions values, that do not need reporting every change, but a snapshot of a dictionary from time to time.

**Warning**
Please be take into consideration https://github.com/Particular/ServiceControl.Monitoring/pull/61#discussion_r140223242 If this approach cannot be used to send a value, maybe we'll need to make it another way.