### PR TITLE
Reporting should be bounded and done in parallel

### DIFF
--- a/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/RingBufferTests.cs
@@ -7,6 +7,7 @@
     public class RingBufferTests
     {
         RingBuffer ringBuffer;
+        const int MaxConsume = 100;
 
         [SetUp]
         public void SetUp()
@@ -132,7 +133,7 @@
                     // read till it returns
                     do
                     {
-                        read = ringBuffer.Consume(chunk =>
+                        read = ringBuffer.Consume(MaxConsume,chunk =>
                         {
                             foreach (var value in chunk)
                             {
@@ -154,7 +155,7 @@
 
         void Consume(params long[] values)
         {
-            var read = ringBuffer.Consume(entries =>
+            var read = ringBuffer.Consume(values.Length, entries =>
             {
                 CollectionAssert.AreEqual(values, entries.Select(e => e.Value).ToArray());
             });

--- a/src/ServiceControl.Monitoring.Data/RawDataReporter.cs
+++ b/src/ServiceControl.Monitoring.Data/RawDataReporter.cs
@@ -12,7 +12,7 @@
     {
         const int DefaultFlushSize = 1028; // for entries written on 16bytes this will give 16kB
         const int MaxDefaultFlushSize = 2048; // for entries written on 16byte this will give 32kB
-        internal const int ParallelConsumers = 4;
+        internal const int MaxParallelConsumers = 4;
         readonly RingBuffer buffer;
         readonly int flushSize;
         readonly int maxFlushSize;
@@ -36,7 +36,7 @@
         public RawDataReporter(Func<byte[], Task> sender, RingBuffer buffer, WriteOutput outputWriter, int flushSize, TimeSpan maxSpinningTime)
             : this(sender, buffer, outputWriter, flushSize, MaxDefaultFlushSize, maxSpinningTime)
         {
-            
+
         }
 
         public RawDataReporter(Func<byte[], Task> sender, RingBuffer buffer, WriteOutput outputWriter, int flushSize, int maxFlushSize, TimeSpan maxSpinningTime)
@@ -56,7 +56,7 @@
         {
             reporter = Task.Run(async () =>
             {
-                var consumers = new List<Task>();
+                var consumers = new List<Task>(MaxParallelConsumers + 1);
 
                 while (cancellationTokenSource.IsCancellationRequested == false)
                 {
@@ -80,7 +80,7 @@
                         await Task.Delay(singleSpinningTime).ConfigureAwait(false);
                     }
 
-                    if (consumers.Count >= ParallelConsumers)
+                    if (consumers.Count >= MaxParallelConsumers)
                     {
                         var task = await Task.WhenAny(consumers).ConfigureAwait(false);
                         consumers.Remove(task);

--- a/src/ServiceControl.Monitoring.Data/RingBuffer.cs
+++ b/src/ServiceControl.Monitoring.Data/RingBuffer.cs
@@ -68,7 +68,7 @@
         }
 
         // Consumes a chunk of entries. This method will call onChunk zero, or one time. No multiple calls will be issued.
-        internal int Consume(Action<ArraySegment<Entry>> onChunk)
+        internal int Consume(int maxFlushSize, Action<ArraySegment<Entry>> onChunk)
         {
             var consume = Interlocked.CompareExchange(ref nextToConsume, 0, 0);
             var max = Volatile.Read(ref nextToWrite);
@@ -85,7 +85,7 @@
             // a segment [4] followed by consumption of [5, 6] in the next Consume call.
             var epoch = i & EpochMask;
             var length = 0;
-            while (Volatile.Read(ref entries[i & SizeMask].Ticks) > 0 && i < max)
+            while (Volatile.Read(ref entries[i & SizeMask].Ticks) > 0 && i < max && length < maxFlushSize)
             {
                 if ((i & EpochMask) != epoch)
                 {


### PR DESCRIPTION
This PR changes the way reports are sent to a monitoring endpoints. It's aim to address issues related to high throughput, high transport latency, small message size situation. It does it in two ways

### Make reporting window bounded
As stated in https://github.com/Particular/NServiceBus.Metrics.ServiceControl/issues/23 there are transports with a strongly limited message size. Previous calculations that were used to estimate the size of a message were wrong. The `RingBuffer` size was 4096 and there was a potential, that the whole buffer will be flushed together. A single report entry takes 16bytes. This means that there was a potential of sending a message of size 

```
4096 * 16b = 64kb
```

This could easily exceed ASQ limit, that has been seen in the referenced issue.
This issue is addressed by introducing a new value of maximum flush size, by default set to `MaxDefaultFlushSize = 2048`. This ensures, that even for ASQ limit of the data will be 32kb (type names a.k.a are not included)

```
2048 * 16b = 32kb
```

### Make reporting parallel
For "remote" transports, like all the Azure transports a single write can take a significant amount of time. There was a proposal of making the writes parallel and allow some degree of it https://github.com/Particular/ServiceControl.Monitoring.Data/issues/10 . This PR introduces a parallelism of 4, allowing consuming the buffer in a much rate.