### PR TITLE
Fix NUnit

### DIFF
--- a/src/ServiceControl.Monitoring.Data.Tests/LongValueWriterTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/LongValueWriterTests.cs
@@ -5,8 +5,8 @@
     public class LongValueWriterTests : WriterTestBase
     {
         public LongValueWriterTests()
-            : base(LongValueWriterV1.Write)
         {
+            SetWriter(LongValueWriterV1.Write);
         }
 
         [Test]

--- a/src/ServiceControl.Monitoring.Data.Tests/OccurrenceWriterTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/OccurrenceWriterTests.cs
@@ -5,8 +5,8 @@
     public class OccurrenceWriterTests : WriterTestBase
     {
         public OccurrenceWriterTests()
-            : base(OccurrenceWriterV1.Write)
         {
+            SetWriter(OccurrenceWriterV1.Write);
         }
 
         [Test]

--- a/src/ServiceControl.Monitoring.Data.Tests/TaggedLongValueWriterTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/TaggedLongValueWriterTests.cs
@@ -4,15 +4,14 @@
     using System.IO;
     using System.Text;
     using NUnit.Framework;
-    using NUnit.Framework.Internal;
 
     public class TaggedLongValueWriterTests : WriterTestBase
     {
         static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
 
         public TaggedLongValueWriterTests()
-            : base(Write)
         {
+            SetWriter(Write);
         }
 
         [Test]
@@ -45,7 +44,7 @@
             const long value = 1345347;
 
             const string tagName = "this is a test tag value 111!!!";
-            var tagId = Writer.GetTagId(tagName);
+            var tagId = writer.GetTagId(tagName);
             var bytes = NoBom.GetBytes(tagName);
 
             var entry = new RingBuffer.Entry { Ticks = ticks, Value = value, Tag = tagId };
@@ -80,11 +79,11 @@
             const int timeDiff = 1;
 
             const string tagName1 = "this is a test tag value 111!!!";
-            var tagId1 = Writer.GetTagId(tagName1);
+            var tagId1 = writer.GetTagId(tagName1);
             var bytes1 = NoBom.GetBytes(tagName1);
 
             const string tagName2 = "this is another test tag value 222@@@ Even longer than the first one!";
-            var tagId2 = Writer.GetTagId(tagName2);
+            var tagId2 = writer.GetTagId(tagName2);
             var bytes2 = NoBom.GetBytes(tagName2);
 
             Write(
@@ -122,18 +121,14 @@
         [SetUp]
         public new void SetUp()
         {
-             Writer = new TaggedLongValueWriterV1();
+             writer = new TaggedLongValueWriterV1();
         }
 
-        static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> entries)
+        void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> entries)
         {
-            Writer.Write(outputWriter, entries);
+            writer.Write(outputWriter, entries);
         }
 
-        static TaggedLongValueWriterV1 Writer
-        {
-            get => (TaggedLongValueWriterV1) TestExecutionContext.CurrentContext.CurrentTest.Properties.Get(nameof(TaggedLongValueWriterV1));
-            set => TestExecutionContext.CurrentContext.CurrentTest.Properties.Set(nameof(TaggedLongValueWriterV1), value);
-        }
+        TaggedLongValueWriterV1 writer;
     }
 }

--- a/src/ServiceControl.Monitoring.Data.Tests/TaggedLongValueWriterTests.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/TaggedLongValueWriterTests.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Text;
     using NUnit.Framework;
+    using NUnit.Framework.Internal;
 
     public class TaggedLongValueWriterTests : WriterTestBase
     {
@@ -131,8 +132,8 @@
 
         static TaggedLongValueWriterV1 Writer
         {
-            get => (TaggedLongValueWriterV1) TestContext.CurrentContext.Test.Properties.Get(nameof(TaggedLongValueWriterV1));
-            set => TestContext.CurrentContext.Test.Properties.Set(nameof(TaggedLongValueWriterV1), value);
+            get => (TaggedLongValueWriterV1) TestExecutionContext.CurrentContext.CurrentTest.Properties.Get(nameof(TaggedLongValueWriterV1));
+            set => TestExecutionContext.CurrentContext.CurrentTest.Properties.Set(nameof(TaggedLongValueWriterV1), value);
         }
     }
 }

--- a/src/ServiceControl.Monitoring.Data.Tests/WriterTestBase.cs
+++ b/src/ServiceControl.Monitoring.Data.Tests/WriterTestBase.cs
@@ -11,10 +11,14 @@ namespace ServiceControl.Monitoring.Data.Tests
         BinaryWriter bw;
         Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer;
 
-        internal WriterTestBase(Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer)
+        internal WriterTestBase()
         {
             ms = new MemoryStream();
             bw = new BinaryWriter(ms);
+        }
+
+        internal void SetWriter(Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer)
+        {
             this.writer = writer;
         }
 


### PR DESCRIPTION
Switch to the TestContext to the internal NUnit TestExecutionContext to be able to set properties for the currently executing test.